### PR TITLE
Fixed #86 : Added edit-clear icon. Symbolic link of remove.svg

### DIFF
--- a/FlatWoken/scalable/actions/edit-clear.svg
+++ b/FlatWoken/scalable/actions/edit-clear.svg
@@ -1,0 +1,1 @@
+../apps/dialog-remove.svg


### PR DESCRIPTION
Fix for #86. Result:

![screenshot from 2014-10-31 19 05 24](https://cloud.githubusercontent.com/assets/3229532/4867231/f4e0ff74-6132-11e4-9740-ef77a4f9bde8.png)
